### PR TITLE
Adds the possibility to provide a specific schema for the flyway meta…

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ repositories {
 tasks {
   generateJooqClasses {
     schemas = arrayOf("public", "other_schema")
+    flywaySchema = "flyway" // schema for the flyway metadata table (not fed into jOOQ class generation)
     basePackageName = "org.jooq.generated"
     inputDirectory.setFrom(project.files("src/main/resources/db/migration"))
     outputDirectory.set(project.layout.buildDirectory.dir("generated-jooq"))

--- a/src/test/resources/V01__init_flyway_schema.sql
+++ b/src/test/resources/V01__init_flyway_schema.sql
@@ -1,0 +1,7 @@
+create schema if not exists other;
+
+create table other.foo
+(
+    id   UUID primary key,
+    data JSONB not null
+);


### PR DESCRIPTION
… data table.

Flyway will automatically add the flyway meta data table (flyway_schema_history) to the first schema provided. Therefore jOOQ will also generate a class for it, which might (or should) not be needed in the production code. This change adds the possibility to provide a specific schema for the meta data table which will not be fed into the jOOQ class generation.