### PR TITLE
Make GenerateJooqClassesTask Cacheable

### DIFF
--- a/src/main/kotlin/com/revolut/jooq/GenerateJooqClassesTask.kt
+++ b/src/main/kotlin/com/revolut/jooq/GenerateJooqClassesTask.kt
@@ -16,6 +16,7 @@ import java.io.IOException
 import java.net.URL
 import java.net.URLClassLoader
 
+@CacheableTask
 open class GenerateJooqClassesTask : DefaultTask() {
     @Input
     var schemas = arrayOf("public")
@@ -33,8 +34,10 @@ open class GenerateJooqClassesTask : DefaultTask() {
     val generatorCustomizer = project.objects.property(GeneratorCustomizer::class).convention(NOOP)
 
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     val inputDirectory = project.objects.fileCollection().from("src/main/resources/db/migration")
     @OutputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     val outputDirectory = project.objects.directoryProperty().convention(project.layout.buildDirectory.dir("generated-jooq"))
 
     @Internal

--- a/src/main/kotlin/com/revolut/jooq/GenerateJooqClassesTask.kt
+++ b/src/main/kotlin/com/revolut/jooq/GenerateJooqClassesTask.kt
@@ -37,7 +37,6 @@ open class GenerateJooqClassesTask : DefaultTask() {
     @PathSensitive(PathSensitivity.RELATIVE)
     val inputDirectory = project.objects.fileCollection().from("src/main/resources/db/migration")
     @OutputDirectory
-    @PathSensitive(PathSensitivity.RELATIVE)
     val outputDirectory = project.objects.directoryProperty().convention(project.layout.buildDirectory.dir("generated-jooq"))
 
     @Internal


### PR DESCRIPTION
Generated classes has a unique timestamp and `serialVersionUID` and because of this, cacheable tasks in dependent projects are always have different input, which prevents to use gradle cache for them. 
This PR makes `generateJooqClasses` task cacheable and resolves above issue for dependent projects.

Notes: 
* I haven't tested caching for all type of inputs, so I don't know how some properties or jvmArgs will impact input. 