### PR TITLE
Volume cleanup and 100% CPU issues

### DIFF
--- a/src/main/kotlin/com/revolut/jooq/Docker.kt
+++ b/src/main/kotlin/com/revolut/jooq/Docker.kt
@@ -70,8 +70,6 @@ class Docker(private val imageName: String,
                 .withAttachStdout(true)
                 .exec()
         docker.execStartCmd(execCreate.id)
-                .withTty(true)
-                .withStdIn(`in`)
                 .exec(ExecStartResultCallback(out, err))
                 .awaitCompletion()
     }

--- a/src/main/kotlin/com/revolut/jooq/Docker.kt
+++ b/src/main/kotlin/com/revolut/jooq/Docker.kt
@@ -82,7 +82,10 @@ class Docker(private val imageName: String,
 
     private fun removeContainer() {
         try {
-            docker.removeContainerCmd(containerName).withForce(true).exec()
+            docker.removeContainerCmd(containerName)
+                    .withRemoveVolumes(true)
+                    .withForce(true)
+                    .exec()
         } catch (e: Exception) {
         }
     }


### PR DESCRIPTION
Fixes the following two issues (for more information see commit comments):
- missing volume cleanup
- 100% CPU issue on MacOS systems (also see probably related `docker-java` issue [here](https://github.com/docker-java/docker-java/issues/1350))