### PR TITLE
Upgrade to Java Docker client 3.2.12

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,7 +113,7 @@ afterEvaluate {
 dependencies {
     implementation("org.jooq:jooq-codegen:3.14.8")
     implementation("org.glassfish.jaxb:jaxb-runtime:2.3.3")
-    implementation("com.github.docker-java:docker-java-transport-okhttp:3.2.8")
+    implementation("com.github.docker-java:docker-java-transport-okhttp:3.2.12")
     implementation("org.flywaydb:flyway-core:6.4.3")
     implementation("org.zeroturnaround:zt-exec:1.12")
     compileOnly("javax.annotation:javax.annotation-api:1.3.2")


### PR DESCRIPTION
Version 3.2.12 of the Docker client improves Windows compatibility by defaulting to named pipes rather than UNIX-domain sockets to talk to the Docker daemon on Windows. Previously, users had to explicitly set `DOCKER_HOST` on Windows.

Fixes #15
